### PR TITLE
Update Install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Generative Adversarial Network implementation that generates Sharingans. This 
 
 or just run the following command
 ```
-pip install -r requirements.txt
+pip install torch===1.6.0 torchvision===0.7.0 -f https://download.pytorch.org/whl/torch_stable.html
 ```
 
 


### PR DESCRIPTION
People on normal pip or virtualenvs can't use this command because torch doesnt have a stable version 1.6.0 on the pypi repo. Unless you have conda you must run:

```
pip install torch===1.6.0 torchvision===0.7.0 -f https://download.pytorch.org/whl/torch_stable.html
```